### PR TITLE
🐞 Don't use default shape on component updates.

### DIFF
--- a/src/modecs.js
+++ b/src/modecs.js
@@ -314,7 +314,7 @@ module.exports = ({
     const updateComponent = (id, type, values) => {
         return Object.assign(
             component_entityId[type][id], 
-            shapeWithValues(component_shape[type], values)
+            values
         )
     }
 


### PR DESCRIPTION
When we call `updateComponent`, its nice to be able to update just one property without overwriting the entire component state.